### PR TITLE
Text search is now enabled

### DIFF
--- a/public/assets/javascript/catalog/catalog-search.js
+++ b/public/assets/javascript/catalog/catalog-search.js
@@ -1,0 +1,37 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const searchInput = document.getElementById("searchBar");
+    const searchTerm = searchInput.value.trim().toLowerCase();
+  
+    // Trigger search if the input is pre-filled
+    if (searchTerm) {
+        performSearch(searchTerm);
+    }
+    
+    // Attach the input event listener
+    searchInput.addEventListener("input", debounce(function () {
+        performSearch(this.value.trim().toLowerCase());
+    }, 300));
+});
+
+// Search function
+function performSearch(searchTerm) {
+    const items = document.querySelectorAll(".catalog-item");
+
+    items.forEach(item => {
+        const text = item.textContent.toLowerCase();
+        if (text.includes(searchTerm)) {
+            item.classList.remove("visually-hidden");
+        } else {
+            item.classList.add("visually-hidden");
+        }
+    });
+}
+
+// Debounce function to improve performance
+function debounce(func, delay) {
+    let timer;
+    return function (...args) {
+        clearTimeout(timer);
+        timer = setTimeout(() => func.apply(this, args), delay);
+    };
+}  

--- a/views/pages/home.php
+++ b/views/pages/home.php
@@ -9,9 +9,9 @@
     <div class="row h-100 align-items-center justify-content-center">
       <div class="col-12 col-md-8 text-center">
         <h1 class="text-img-overlay display-1 text-white fw-bold mb-5">Welcome to the Library</h1>
-        <form action="">
+        <form action="view-catalog.php" method="GET">
             <div class="input-group mb-3">
-              <input type="text" class="form-control" placeholder="i.e. To Kill A Mockingbird" aria-label="Search" aria-describedby="basic-addon2">
+              <input name="searchTerm" type="text" class="form-control" placeholder="i.e. To Kill A Mockingbird" aria-label="Search" aria-describedby="basic-addon2">
               <button class="btn btn-primary btn-outline-light" id="search">
                 <i class="bi bi-search"></i>
               </span>
@@ -26,16 +26,17 @@
   <div class="container">
     <div class="row row-cols-1 row-cols-md-3 g-4">
       <div class="col">
-        <div class="card text-center">
+        <div class="card text-center border-primary">
           <div class="card-body text-primary">
             <h1><i class="bi bi-collection-fill"></i></h1>
             <h3 class="mb-3">Comprehensive Catalog</h3>
             <p class="text-black mb-0">Explore our comprehensive catalog of books, music, movies, and more—something for every interest and age. Discover your next favorite!</p>
+            <a href="view-catalog.php" class="stretched-link"></a>
           </div>
         </div>
       </div>
       <div class="col">
-        <div class="card text-center">
+        <div class="card text-center border-success">
           <div class="card-body text-success">
             <h1><i class="bi bi-easel3-fill"></i></h1>
             <h3 class="mb-3">Engaging Classes</h3>
@@ -44,7 +45,7 @@
         </div>
       </div>
       <div class="col">
-        <div class="card text-center">
+        <div class="card text-center border-danger">
           <div class="card-body text-danger">
             <h1><i class="bi bi-calendar-event-fill"></i></h1>
             <h3 class="mb-3">Exciting Events</h3>

--- a/views/pages/view-catalog.php
+++ b/views/pages/view-catalog.php
@@ -16,7 +16,13 @@
                     <div class="offcanvas-body">
                         <div class="input-group flex-nowrap">
                             <span class="input-group-text" id="addon-wrapping"><i class="bi bi-search"></i></span>
-                            <input disabled type="text" name="search" class="form-control" aria-label="Search" aria-describedby="addon-wrapping">
+                            <input id="searchBar" type="text" name="search" class="form-control" aria-label="Search" aria-describedby="addon-wrapping"
+                            value="<?php 
+                                if(isset($_GET['searchTerm'])) {
+                                    echo $_GET['searchTerm'];
+                                }
+                            ?>"
+                            >
                         </div>
                     </div>
                 </div>
@@ -58,7 +64,7 @@
                         $img = ($row['ImagePath'] ?? 'ImageDirectory/default-image.jpg');
 
                         echo <<<_END
-                        <div class="col">
+                        <div class="col catalog-item">
                             <div class="card border-0">
                                 <img src="../../$img" class="card-img-top catalog-item-img mb-3" alt="...">
                                 <div class="card-body border rounded" style="height:16rem">
@@ -77,6 +83,8 @@
         </div>
     </div>
 </main>
+
+<script src="../../public/assets/javascript/catalog/catalog-search.js"></script>
 
 <!-- Footer -->
 <?php include_once '../partials/footer.php'; ?>


### PR DESCRIPTION
## Description

I've built out the search functionality. It's comprised of two pieces:

1. On the home page, the search bar may be populated and upon "submit", a GET request fires to `view-catalog.php` attaching the search term as a parameter. That value will auto-populate the search box on the `view-catalog.php`
2. In `view-catalog.php`, I injected some JavaScript to "listen" for changes to the search box. Upon change, it will compare the search term to book titles already loaded onto our page. It will temporarily "hide" the html for books not matching the search criteria. 


## How to test

Use `git pull` in your local repository and `git checkout adam/searching-functionality`. Launch the WAMP server and navigate to the home page. Input text into the main search bar. Ensure it navigates to the catalog page and auto-populates the input field and filters the content. Make some changes to the input field and ensure it changes the book content.